### PR TITLE
Implement Jellyfin NativeShell to support DoVi playback (WebView1)

### DIFF
--- a/Component/IMessageHandler.cs
+++ b/Component/IMessageHandler.cs
@@ -1,0 +1,8 @@
+﻿using Windows.Data.Json;
+namespace Jellyfin.Component
+{
+    public interface IMessageHandler
+    {
+        void HandleJsonNotification(JsonObject jsonObject);
+    }
+}

--- a/Component/Jellyfin-component.csproj
+++ b/Component/Jellyfin-component.csproj
@@ -1,0 +1,142 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}</ProjectGuid>
+    <OutputType>winmdobj</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Jellyfin.Component</RootNamespace>
+    <AssemblyName>Jellyfin.Component</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+    <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <AllowCrossPlatformRetargeting>false</AllowCrossPlatformRetargeting>
+    <RuntimeIdentifiers>win10-arm;win10-arm-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot</RuntimeIdentifiers>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <OutputPath>bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
+    <PlatformTarget>ARM64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
+    <PlatformTarget>ARM64</PlatformTarget>
+    <OutputPath>bin\ARM64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="IMessageHandler.cs" />
+    <Compile Include="WebViewBridge.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+      <Version>5.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+    <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Component/Properties/AssemblyInfo.cs
+++ b/Component/Properties/AssemblyInfo.cs
@@ -1,0 +1,29 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("jellyfin-uwp-component")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("jellyfin-uwp-component")]
+[assembly: AssemblyCopyright("Copyright ©  2024")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: ComVisible(false)]

--- a/Component/WebViewBridge.cs
+++ b/Component/WebViewBridge.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Diagnostics;
+using Windows.Data.Json;
+using Windows.Foundation.Metadata;
+
+namespace Jellyfin.Component
+{
+    /**
+    * Workaround for not being able to call window.external.notify
+    * from a non-https & non-whitelisted uri
+    * See https://stackoverflow.com/a/60301805 for more info
+    */
+    [AllowForWeb]
+    public sealed class WebViewBridge
+    {
+        private readonly IMessageHandler messageHandler;
+
+        public WebViewBridge(IMessageHandler messageHandler)
+        {
+            this.messageHandler = messageHandler;
+        }
+
+        public void PostMessage(string message)
+        {
+            try
+            {
+                if (JsonObject.TryParse(message, out JsonObject jsonObject))
+                {
+                    messageHandler.HandleJsonNotification(jsonObject);
+                }
+                else
+                {
+                    Debug.WriteLine($"Failed to parse message as JSON: {message}");
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine($"Failed to process PostMessage with message: {message}", e);
+            }
+        }
+
+        public void LogMessage(string message)
+        {
+            Debug.WriteLine(message);
+        }
+    }
+}

--- a/Jellyfin/Core/FullScreenManager.cs
+++ b/Jellyfin/Core/FullScreenManager.cs
@@ -1,0 +1,189 @@
+using Jellyfin.Core;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Windows.Data.Json;
+using Windows.Graphics.Display.Core;
+using Windows.UI.ViewManagement;
+namespace Jellyfin.Utils
+{
+    public sealed class FullScreenManager
+    {
+        private async Task SwitchToBestDisplayMode(uint videoWidth, uint videoHeight, double videoFrameRate,
+           HdmiDisplayHdrOption hdmiDisplayHdrOption)
+        {
+            HdmiDisplayMode bestDisplayMode =
+                GetBestDisplayMode(videoWidth, videoHeight, videoFrameRate, hdmiDisplayHdrOption);
+            if (bestDisplayMode != null)
+            {
+                await HdmiDisplayInformation.GetForCurrentView()
+                    ?.RequestSetCurrentDisplayModeAsync(bestDisplayMode, hdmiDisplayHdrOption);
+            }
+        }
+
+        private HdmiDisplayHdrOption GetHdmiDisplayHdrOption(string videoRangeType)
+        {
+            HdmiDisplayInformation hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
+            if (hdmiDisplayInformation == null)
+            {
+                return HdmiDisplayHdrOption.None;
+            }
+
+            IReadOnlyList<HdmiDisplayMode> supportedDisplayModes = hdmiDisplayInformation.GetSupportedDisplayModes();
+            bool displaySupportsDoVi = supportedDisplayModes.Any(mode => mode.IsDolbyVisionLowLatencySupported);
+            bool displaySupportsHdr = supportedDisplayModes.Any(mode => mode.IsSmpte2084Supported);
+
+            HdmiDisplayHdrOption hdrOtherwiseSdr =
+                displaySupportsHdr ? HdmiDisplayHdrOption.Eotf2084 : HdmiDisplayHdrOption.None;
+            HdmiDisplayHdrOption doViOtherwiseHdrOtherwiseSdr =
+                displaySupportsDoVi ? HdmiDisplayHdrOption.DolbyVisionLowLatency : hdrOtherwiseSdr;
+
+            switch (videoRangeType)
+            {
+                // Xbox only supports DOVI profile 5
+                case "DOVI":
+                    return doViOtherwiseHdrOtherwiseSdr;
+                case "DOVIWithHDR10":
+                case "DOVIWithHLG":
+                case "HDR":
+                case "HDR10":
+                case "HDR10Plus":
+                case "HLG":
+                    return hdrOtherwiseSdr;
+                case "DOVIWithSDR":
+                case "SDR":
+                case "Unknown":
+                default:
+                    return HdmiDisplayHdrOption.None;
+            }
+        }
+
+        private Predicate<HdmiDisplayMode> ToRefreshRateMatchesPredicate(double refreshRate)
+        {
+            bool RefreshRateMatches(HdmiDisplayMode mode) => Math.Abs(refreshRate - mode.RefreshRate) <= 0.5;
+            return RefreshRateMatches;
+        }
+
+        private Predicate<HdmiDisplayMode> ToResolutionMatchesPredicate(uint width, uint height)
+        {
+            bool ResolutionMatches(HdmiDisplayMode mode) => mode.ResolutionWidthInRawPixels == width ||
+                                          mode.ResolutionHeightInRawPixels == height;
+            return ResolutionMatches;
+        }
+
+        private Predicate<HdmiDisplayMode> ToHdmiDisplayHdrOptionMatchesPredicate(
+            HdmiDisplayHdrOption hdmiDisplayHdrOption)
+        {
+            bool HdrMatches(HdmiDisplayMode mode) => hdmiDisplayHdrOption == HdmiDisplayHdrOption.None ||
+                                                             (hdmiDisplayHdrOption ==
+                                                              HdmiDisplayHdrOption.DolbyVisionLowLatency &&
+                                                              mode.IsDolbyVisionLowLatencySupported) ||
+                                                             (hdmiDisplayHdrOption == HdmiDisplayHdrOption.Eotf2084 &&
+                                                              mode.IsSmpte2084Supported);
+            return HdrMatches;
+        }
+
+        private HdmiDisplayMode GetBestDisplayMode(uint videoWidth, uint videoHeight, double videoFrameRate,
+            HdmiDisplayHdrOption hdmiDisplayHdrOption)
+        {
+            HdmiDisplayInformation hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
+            IEnumerable<HdmiDisplayMode> supportedHdmiDisplayModes = hdmiDisplayInformation.GetSupportedDisplayModes();
+            // `GetHdmiDisplayHdrOption(...)` ensures the HdmiDisplayHdrOption is always a mode the display supports
+            Predicate<HdmiDisplayMode> hdrMatchesPredicate =
+                ToHdmiDisplayHdrOptionMatchesPredicate(hdmiDisplayHdrOption);
+            IEnumerable<HdmiDisplayMode> hdmiDisplayModes =
+                supportedHdmiDisplayModes.Where(mode => hdrMatchesPredicate.Invoke(mode));
+
+            bool filteredToVideoResolution = false;
+            if (Central.Settings.AutoResolution)
+            {
+                Predicate<HdmiDisplayMode> resolutionMatchesVideoPredicate =
+                    ToResolutionMatchesPredicate(videoWidth, videoHeight);
+                IEnumerable<HdmiDisplayMode> matchingResolution =
+                    hdmiDisplayModes.Where(mode => resolutionMatchesVideoPredicate.Invoke(mode));
+                if (matchingResolution.Any())
+                {
+                    hdmiDisplayModes = matchingResolution;
+                    filteredToVideoResolution = true;
+                }
+            }
+            HdmiDisplayMode currentHdmiDisplayMode = hdmiDisplayInformation.GetCurrentDisplayMode();
+            Predicate<HdmiDisplayMode> resolutionMatchesCurrentDisplayPredicate = ToResolutionMatchesPredicate(
+                currentHdmiDisplayMode.ResolutionWidthInRawPixels,
+                currentHdmiDisplayMode.ResolutionHeightInRawPixels);
+            if (!filteredToVideoResolution)
+            {
+                hdmiDisplayModes =
+                    hdmiDisplayModes.Where(mode => resolutionMatchesCurrentDisplayPredicate.Invoke(mode));
+            }
+
+            if (Central.Settings.AutoRefreshRate)
+            {
+                Predicate<HdmiDisplayMode> refreshRateMatchesVideoPredicate =
+                    ToRefreshRateMatchesPredicate(videoFrameRate);
+                IEnumerable<HdmiDisplayMode> matchingRefreshRates =
+                    hdmiDisplayModes.Where(mode => refreshRateMatchesVideoPredicate.Invoke(mode));
+                if (matchingRefreshRates.Any())
+                {
+                    return matchingRefreshRates.First();
+                }
+            }
+
+            Predicate<HdmiDisplayMode> refreshRateMatchesCurrentDisplayPredicate =
+                ToRefreshRateMatchesPredicate(currentHdmiDisplayMode.RefreshRate);
+            // fall back to current resolution/refreshRate as a mode that supports the hdmiDisplayHdrOption is required. 
+            return hdmiDisplayModes.Where(mode => resolutionMatchesCurrentDisplayPredicate.Invoke(mode))
+                .Where(mode => refreshRateMatchesCurrentDisplayPredicate.Invoke(mode)).FirstOrDefault();
+        }
+
+        private async Task SetDefaultDisplayModeAsync()
+        {
+            await HdmiDisplayInformation.GetForCurrentView()?.SetDefaultDisplayModeAsync();
+        }
+
+        public async Task EnableFullscreenAsync(JsonObject args)
+        {
+            if (AppUtils.IsXbox)
+            {
+                if (args != null)
+                {
+                    try
+                    {
+                        uint videoWidth = (uint)args.GetNamedNumber("videoWidth");
+                        uint videoHeight = (uint)args.GetNamedNumber("videoHeight");
+                        double videoFrameRate = args.GetNamedNumber("videoFrameRate");
+                        string videoRangeType = args.GetNamedString("videoRangeType");
+                        HdmiDisplayHdrOption hdmiDisplayHdrOption = GetHdmiDisplayHdrOption(videoRangeType);
+                        await SwitchToBestDisplayMode(videoWidth, videoHeight, videoFrameRate, hdmiDisplayHdrOption);
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine("Error during SwitchToBestDisplayMode", ex);
+                    }
+                }
+                else
+                {
+                    Debug.WriteLine("enableFullscreenAsync called with no args");
+                }
+            }
+            else
+            {
+                ApplicationView.GetForCurrentView().TryEnterFullScreenMode();
+            }
+        }
+
+        public async void DisableFullScreen()
+        {
+            if (AppUtils.IsXbox)
+            {
+                await SetDefaultDisplayModeAsync();
+            }
+            else
+            {
+                ApplicationView.GetForCurrentView().ExitFullScreenMode();
+            }
+        }
+    }
+}

--- a/Jellyfin/Core/MessageHandler.cs
+++ b/Jellyfin/Core/MessageHandler.cs
@@ -1,0 +1,62 @@
+using Jellyfin.Component;
+using Jellyfin.Utils;
+using Jellyfin.Views;
+using System.Diagnostics;
+using Windows.Data.Json;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+namespace Jellyfin.Core
+{
+    public class MessageHandler : IMessageHandler
+    {
+        private readonly Frame frame;
+        private readonly FullScreenManager fullScreenManager;
+        public MessageHandler(Frame frame)
+        {
+            this.frame = frame;
+            fullScreenManager = new FullScreenManager();
+        }
+        public async void HandleJsonNotification(JsonObject json)
+        {
+            string eventType = json.GetNamedString("type");
+            JsonObject args = json.GetNamedObject("args");
+
+            if (eventType == "enableFullscreen")
+            {
+                await fullScreenManager.EnableFullscreenAsync(args);
+            }
+            else if (eventType == "disableFullscreen")
+            {
+                fullScreenManager.DisableFullScreen();
+            }
+            else if (eventType == "selectServer")
+            {
+                Central.Settings.JellyfinServer = null;
+                _ = frame.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                {
+                    frame.Navigate(typeof(OnBoarding));
+                });
+            }
+            else if (eventType == "openClientSettings")
+            {
+                _ = frame.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                {
+                    frame.Navigate(typeof(Settings));
+                });
+            }
+            else if (eventType == "exit")
+            {
+                Exit();
+            }
+            else
+            {
+                Debug.WriteLine($"Unexpected JSON message: {eventType}");
+            }
+        }
+        private void Exit()
+        {
+            Application.Current.Exit();
+        }
+    }
+}

--- a/Jellyfin/Core/NativeShellScriptLoader.cs
+++ b/Jellyfin/Core/NativeShellScriptLoader.cs
@@ -1,0 +1,58 @@
+
+
+using Jellyfin.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Windows.Graphics.Display.Core;
+using Windows.Storage;
+using Windows.System.Profile;
+
+namespace Jellyfin.Core
+{
+    public static class NativeShellScriptLoader
+    {
+        public static async Task<string> LoadNativeShellScript()
+        {
+            Uri uri = new Uri("ms-appx:///Resources/winuwp.js");
+            StorageFile storageFile = await StorageFile.GetFileFromApplicationUriAsync(uri);
+            string nativeShellScript = await FileIO.ReadTextAsync(storageFile);
+
+            Assembly assembly = Assembly.GetExecutingAssembly();
+            nativeShellScript = nativeShellScript.Replace("APP_NAME",
+                Wrap(assembly.GetCustomAttribute<AssemblyTitleAttribute>().Title, '\''));
+            nativeShellScript = nativeShellScript.Replace("APP_VERSION", Wrap(assembly.GetName().Version.ToString(), '\''));
+
+            string deviceForm = AnalyticsInfo.DeviceForm;
+            if (deviceForm == "Unknown")
+            {
+                deviceForm = AppUtils.GetDeviceFormFactorType().ToString();
+            }
+            nativeShellScript = nativeShellScript.Replace("DEVICE_NAME", Wrap(deviceForm, '\''));
+
+            HdmiDisplayInformation hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
+            if (hdmiDisplayInformation != null)
+            {
+                IReadOnlyList<HdmiDisplayMode> supportedDisplayModes = hdmiDisplayInformation.GetSupportedDisplayModes();
+                bool supportsHdr = supportedDisplayModes.Any(mode => mode.IsSmpte2084Supported);
+                nativeShellScript = nativeShellScript.Replace("SUPPORTS_HDR", supportsHdr.ToString().ToLower());
+                bool supportsDovi = supportedDisplayModes.Any(mode => mode.IsDolbyVisionLowLatencySupported);
+                nativeShellScript = nativeShellScript.Replace("SUPPORTS_DOVI", supportsDovi.ToString().ToLower());
+            }
+            else
+            {
+                nativeShellScript = nativeShellScript.Replace("SUPPORTS_HDR", "undefined");
+                nativeShellScript = nativeShellScript.Replace("SUPPORTS_DOVI", "undefined");
+            }
+            
+
+            return nativeShellScript;
+        }
+        private static string Wrap(string text, char c)
+        {
+            return c + text + c;
+        }
+    }
+}

--- a/Jellyfin/Core/SettingsManager.cs
+++ b/Jellyfin/Core/SettingsManager.cs
@@ -11,6 +11,8 @@ namespace Jellyfin.Core
     {
         string CONTAINER_SETTINGS = "APPSETTINGS";
         string SETTING_SERVER = "SERVER";
+        string AUTO_RESOLUTION = "AUTO_RESOLUTION";
+        string AUTO_REFRESH_RATE = "AUTO_REFRESH_RATE";
 
         private ApplicationDataContainer LocalSettings => ApplicationData.Current.LocalSettings;
         private ApplicationDataContainer ContainerSettings
@@ -31,6 +33,18 @@ namespace Jellyfin.Core
         {
             get => GetProperty<String>(SETTING_SERVER);
             set => SetProperty(SETTING_SERVER, value);
+        }
+
+        public bool AutoResolution
+        {
+            get => GetProperty<bool>(AUTO_RESOLUTION);
+            set => SetProperty(AUTO_RESOLUTION, value);
+        }
+
+        public bool AutoRefreshRate
+        {
+            get => GetProperty<bool>(AUTO_REFRESH_RATE);
+            set => SetProperty(AUTO_REFRESH_RATE, value);
         }
 
         private void SetProperty(String propertyName, object value)

--- a/Jellyfin/Jellyfin.csproj
+++ b/Jellyfin/Jellyfin.csproj
@@ -133,6 +133,9 @@
       <DependentUpon>JellyfinWebView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Core\Central.cs" />
+    <Compile Include="Core\FullScreenManager.cs" />
+    <Compile Include="Core\MessageHandler.cs" />
+    <Compile Include="Core\NativeShellScriptLoader.cs" />
     <Compile Include="Core\SettingsManager.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
@@ -142,6 +145,9 @@
     <Compile Include="Utils\DeviceFormFactorType.cs" />
     <Compile Include="Views\OnBoarding.xaml.cs">
       <DependentUpon>OnBoarding.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\Settings.xaml.cs">
+      <DependentUpon>Settings.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -198,6 +204,8 @@
     <Content Include="Assets\Wide310x150Logo.scale-150.png" />
     <Content Include="Assets\Wide310x150Logo.scale-400.png" />
     <Content Include="Fonts\NotoSans-Regular.ttf" />
+    <Content Include="Resources\redirectlogs.js" />
+    <Content Include="Resources\winuwp.js" />
     <None Include="Package.StoreAssociation.xml" />
     <Content Include="Properties\Default.rd.xml" />
     <Content Include="Assets\SplashScreen.scale-200.png" />
@@ -231,6 +239,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Views\Settings.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
@@ -242,6 +254,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Jellyfin_TemporaryKey.pfx" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Component\Jellyfin-component.csproj">
+      <Project>{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}</Project>
+      <Name>Jellyfin-component</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
 </Project>

--- a/Jellyfin/Package.appxmanifest
+++ b/Jellyfin/Package.appxmanifest
@@ -4,7 +4,8 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap mp rescap">
 
   <Identity
     Name="Jellyfin.Jellyfin"
@@ -46,5 +47,6 @@
   <Capabilities>
     <Capability Name="internetClient" />
     <Capability Name="privateNetworkClientServer"/>
+    <rescap:Capability Name="hevcPlayback" />
   </Capabilities>
 </Package>

--- a/Jellyfin/Resources/redirectlogs.js
+++ b/Jellyfin/Resources/redirectlogs.js
@@ -1,0 +1,20 @@
+// Visual Studio 2019 dropped WebView debugging support.
+// This redirects the console logs so they're visible
+window.console.log = function (...data) {
+    WebViewBridge.logMessage('window.console.log ' + JSON.stringify(data));
+};
+window.console.debug = function (...data) {
+    WebViewBridge.logMessage('window.console.debug ' + JSON.stringify(data));
+};
+window.console.info = function (...data) {
+    WebViewBridge.logMessage('window.console.info ' + JSON.stringify(data));
+};
+window.console.warn = function (...data) {
+    WebViewBridge.logMessage('window.console.warn ' + JSON.stringify(data));
+};
+window.console.error = function (...data) {
+    WebViewBridge.logMessage('window.console.error ' + JSON.stringify(data));
+};
+window.onerror = function (...data) {
+    WebViewBridge.logMessage('window.onerror ' + JSON.stringify(data));
+};

--- a/Jellyfin/Resources/winuwp.js
+++ b/Jellyfin/Resources/winuwp.js
@@ -1,0 +1,146 @@
+(function (appName, appVersion, deviceName, supportsHdr10, supportsDolbyVision) {
+    'use strict';
+
+    console.log('Windows UWP adapter');
+
+    const xbox = deviceName.toLowerCase().indexOf('xbox') !== -1;
+    const xboxSeries = deviceName.toLowerCase().indexOf('xbox series') !== -1;
+    const mobile = deviceName.toLowerCase().indexOf('mobile') !== -1;
+
+    function postMessage(type, args = {}) {
+        console.debug(`AppHost.${type}`, args);
+        const payload = {
+            'type': type,
+            'args': args
+        };
+
+        if (WebViewBridge) {
+            // WebView
+            WebViewBridge.postMessage(JSON.stringify(payload));
+        } else {
+            // Webview2
+            window.chrome.webview.postMessage(JSON.stringify(payload));
+        }
+    }
+
+    const AppInfo = {
+        deviceName: deviceName,
+        appName: appName,
+        appVersion: appVersion
+    };
+
+    // List of supported features
+    const SupportedFeatures = [
+        'displaylanguage',
+        'displaymode',
+        'exit',
+        'exitmenu',
+        'externallinkdisplay',
+        'externallinks',
+        'htmlaudioautoplay',
+        'htmlvideoautoplay',
+        'multiserver',
+        'otherapppromotions',
+        'screensaver',
+        'subtitleappearancesettings',
+        'subtitleburnsettings',
+        'targetblank'
+    ];
+
+    if (xbox || mobile) {
+        SupportedFeatures.push('physicalvolumecontrol');
+    }
+
+    // Only devices with HdmiDisplayInformation have settings currently
+    if (xbox) {
+        SupportedFeatures.push('clientsettings');
+    }
+
+    console.debug('SupportedFeatures', SupportedFeatures);
+
+    window.NativeShell = {
+        AppHost: {
+            init: function () {
+                console.debug('AppHost.init', AppInfo);
+                return Promise.resolve(AppInfo);
+            },
+
+            appName: function () {
+                console.debug('AppHost.appName', AppInfo.appName);
+                return AppInfo.appName;
+            },
+
+            appVersion: function () {
+                console.debug('AppHost.appVersion', AppInfo.appVersion);
+                return AppInfo.appVersion;
+            },
+
+            deviceName: function () {
+                console.debug('AppHost.deviceName', AppInfo.deviceName);
+                return AppInfo.deviceName;
+            },
+
+            exit: function () {
+                postMessage('exit');
+            },
+
+            getDefaultLayout: function () {
+                let layout;
+                if (xbox) {
+                    layout = 'tv';
+                } else if (mobile) {
+                    layout = 'mobile';
+                } else {
+                    layout = 'desktop';
+                }
+                console.debug('AppHost.getDefaultLayout', layout);
+                return layout;
+            },
+
+            getDeviceProfile: function (profileBuilder) {
+                console.debug('AppHost.getDeviceProfile');
+                const options = {};
+                if (supportsHdr10 != null) {
+                    options.supportsHdr10 = supportsHdr10;
+                }
+                if (supportsDolbyVision != null) {
+                    options.supportsDolbyVision = supportsDolbyVision;
+                }
+                if (xboxSeries) {
+                    options.maxVideoWidth = 3840;
+                }
+                return profileBuilder(options);
+            },
+
+            supports: function (command) {
+                const isSupported = command && SupportedFeatures.indexOf(command.toLowerCase()) !== -1;
+                console.debug('AppHost.supports', {
+                    command: command,
+                    isSupported: isSupported
+                });
+                return isSupported;
+            }
+        },
+
+        enableFullscreen: function (videoInfo) {
+            postMessage('enableFullscreen', videoInfo);
+        },
+
+        disableFullscreen: function () {
+            postMessage('disableFullscreen');
+        },
+
+        getPlugins: function () {
+            console.debug('getPlugins');
+            return [];
+        },
+
+        selectServer: function () {
+            postMessage('selectServer');
+        },
+
+        openClientSettings: function () {
+            postMessage('openClientSettings');
+        }
+    };
+})(APP_NAME, APP_VERSION, DEVICE_NAME, SUPPORTS_HDR, SUPPORTS_DOVI);

--- a/Jellyfin/Views/Settings.xaml
+++ b/Jellyfin/Views/Settings.xaml
@@ -1,0 +1,60 @@
+﻿<Page
+    x:Class="Jellyfin.Views.Settings"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Jellyfin.Views"
+    xmlns:c="using:Jellyfin.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid Background="{StaticResource Color0}">
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <c:DeviceFamilyStateTrigger TargetDeviceFamily="Desktop" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="RowHeader.Height" Value="60" />
+                        <Setter Target="logo.HorizontalAlignment" Value="Left" />
+                        <Setter Target="logo.Height" Value="28" />
+                        <Setter Target="logo.Margin" Value="28 0 0 0" />
+                        <Setter Target="txtTitle.FontSize" Value="22" />
+                        <Setter Target="pnlMain.MaxWidth" Value="400" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+        <Grid.RowDefinitions>
+            <RowDefinition x:Name="RowHeader" Height="200" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <StackPanel 
+                x:Name="pnlMain" 
+                HorizontalAlignment="Center" 
+                VerticalAlignment="Top" 
+                Width="640">
+            <TextBlock
+                    x:Name="txtTitle"
+                    Text="Settings" 
+                    Foreground="White" FontSize="{StaticResource FontL}"
+                    Margin="0 0 0 28" FontFamily="{StaticResource JellyfinFamilyFont}"
+                    HorizontalAlignment="Center" />
+
+            <CheckBox 
+                    x:Name="checkBoxAutoRefreshRate"
+                    Content="Set the display refresh rate to the media refresh rate" />
+            <CheckBox 
+                    x:Name="checkBoxAutoResolution"
+                    Content="Set the display resolution to the media resolution" />
+            <Button
+                    x:Name="btnSave"
+                    Style="{StaticResource PrimaryButton}"
+                    Content="Save"  />
+        </StackPanel>
+
+    </Grid>
+</Page>

--- a/Jellyfin/Views/Settings.xaml.cs
+++ b/Jellyfin/Views/Settings.xaml.cs
@@ -1,0 +1,44 @@
+﻿using Jellyfin.Core;
+using Windows.Graphics.Display.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Jellyfin.Views
+{
+    public sealed partial class Settings : Page
+    {
+        public Settings()
+        {
+            this.InitializeComponent();
+            btnSave.Click += BtnSave_Click;
+
+            HdmiDisplayInformation hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
+            checkBoxAutoRefreshRate.IsEnabled = hdmiDisplayInformation != null;
+            checkBoxAutoRefreshRate.IsChecked = Central.Settings.AutoRefreshRate;
+            checkBoxAutoResolution.IsEnabled = hdmiDisplayInformation != null;
+            checkBoxAutoResolution.IsChecked = Central.Settings.AutoResolution;
+        }
+
+        private void BtnSave_Click(object sender, RoutedEventArgs e)
+        {
+            SaveSettings();
+            NavigateToMainPage();
+        }
+
+        private void SaveSettings()
+        {
+            if (checkBoxAutoRefreshRate.IsEnabled)
+            {
+                Central.Settings.AutoRefreshRate = checkBoxAutoRefreshRate.IsChecked ?? false;
+            }
+            if (checkBoxAutoResolution.IsEnabled)
+            {
+                Central.Settings.AutoResolution = checkBoxAutoResolution.IsChecked ?? false;
+            }
+        }
+        private static void NavigateToMainPage()
+        {
+            (Window.Current.Content as Frame).Navigate(typeof(MainPage));
+        }
+    }
+}

--- a/JellyfinUwp.sln
+++ b/JellyfinUwp.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Doc", "Doc", "{A497F636-B20
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin-component", "Component\Jellyfin-component.csproj", "{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
@@ -46,6 +48,22 @@ Global
 		{9BA6E54B-B71A-4C79-8D15-F6C3335432E9}.Release|x86.ActiveCfg = Release|x86
 		{9BA6E54B-B71A-4C79-8D15-F6C3335432E9}.Release|x86.Build.0 = Release|x86
 		{9BA6E54B-B71A-4C79-8D15-F6C3335432E9}.Release|x86.Deploy.0 = Release|x86
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Debug|ARM.ActiveCfg = Debug|ARM
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Debug|ARM.Build.0 = Debug|ARM
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Debug|ARM64.Build.0 = Debug|ARM64
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Debug|x64.ActiveCfg = Debug|x64
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Debug|x64.Build.0 = Debug|x64
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Debug|x86.ActiveCfg = Debug|x86
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Debug|x86.Build.0 = Debug|x86
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Release|ARM.ActiveCfg = Release|ARM
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Release|ARM.Build.0 = Release|ARM
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Release|ARM64.ActiveCfg = Release|ARM64
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Release|ARM64.Build.0 = Release|ARM64
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Release|x64.ActiveCfg = Release|x64
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Release|x64.Build.0 = Release|x64
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Release|x86.ActiveCfg = Release|x86
+		{95412C4F-BAE5-4EF1-9D43-3E7FEBC16EAE}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Implement Jellyfin NativeShell to support DoVi playback
The Xbox must be switched to DoVi mode otherwise videos fail to play.
As a HdmiDisplayMode that supports DoVi must be chosen, the HdmiDisplayMode that best matches the video is alson chosen.

Note:
- `Jellyfin.Component` was added as a workaround to `WebView` disallowing window.external.notify calls from a non-https & non-whitelisted uri. https://stackoverflow.com/a/60301805 for more info
- redirectlogs.js redirects the `WebView` logs to the Visual Studio console as Visual Studio 2019 dropped WebView debugging support.

Tested on Xbox Series X.

Requires
- https://github.com/jellyfin/jellyfin-web/pull/5628
- https://github.com/jellyfin/jellyfin-web/pull/5669

![image](https://github.com/jellyfin/jellyfin-uwp/assets/1393949/e93e7637-bfe7-40cb-be28-33d8946c7f02)
