### PR TITLE
Gamepad Nav Back Support

### DIFF
--- a/Jellyfin/Controls/JellyfinWebView.xaml.cs
+++ b/Jellyfin/Controls/JellyfinWebView.xaml.cs
@@ -30,29 +30,16 @@ namespace Jellyfin.Controls
             WView.NavigationCompleted += JellyfinWebView_NavigationCompleted;
             SystemNavigationManager.GetForCurrentView().BackRequested += Back_BackRequested;
             
-            Gamepad.GamepadAdded += GamepadOnGamepadAdded;
-            Gamepad.GamepadRemoved += GamepadOnGamepadRemoved;
+            Gamepad.GamepadAdded += (object sender, Gamepad e) => {if (!_connectedGamepads.Contains(e)) _connectedGamepads.Add(e); };
+            Gamepad.GamepadRemoved += (object sender, Gamepad e) => { _connectedGamepads.Remove(e); };
             
             _timer = new DispatcherTimer();
             _timer.Interval = TimeSpan.FromMilliseconds(10);
-            _timer.Tick += Timer_Tick;
+            _timer.Tick += GamepadPollingTimer_Tick;
             _timer.Start();
         }
-        
-        private void GamepadOnGamepadRemoved(object sender, Gamepad e)
-        {
-            _connectedGamepads.Remove(e);
-        }
 
-        private void GamepadOnGamepadAdded(object sender, Gamepad e)
-        {
-            if (!_connectedGamepads.Contains(e))
-            {
-                _connectedGamepads.Add(e);
-            }        
-        }
-
-        private void Timer_Tick(object sender, object e)
+        private void GamepadPollingTimer_Tick(object sender, object e)
         {
             foreach (var gamepad in _connectedGamepads)
             {

--- a/Jellyfin/Controls/JellyfinWebView.xaml.cs
+++ b/Jellyfin/Controls/JellyfinWebView.xaml.cs
@@ -18,7 +18,7 @@ namespace Jellyfin.Controls
     {
         private List<Gamepad> _connectedGamepads = new List<Gamepad>();
         private DispatcherTimer _timer;
-        private bool _isGoingBack; // used to make the back button latching
+        private bool _wasBPressed; // used to make the back button latching
         
         public JellyfinWebView()
         {
@@ -58,20 +58,19 @@ namespace Jellyfin.Controls
             {
                 GamepadReading reading = gamepad.GetCurrentReading();
 
-                if ((reading.Buttons & GamepadButtons.B) == GamepadButtons.B && !_isGoingBack)
+                if ((reading.Buttons & GamepadButtons.B) == GamepadButtons.B && !_wasBPressed)
                 {
-                    // todo - make latching (require reset before going back a second time)
                     // Handle B button pressed
                     if (WView.CanGoBack)
                     {
                         WView.GoBack();
-                        _isGoingBack = true;
+                        _wasBPressed = true;
                     }
                 }
 
                 if ((reading.Buttons & GamepadButtons.B) != GamepadButtons.B)
                 {
-                    _isGoingBack = false;
+                    _wasBPressed = false;
                 }
             }
         }

--- a/Jellyfin/Controls/JellyfinWebView.xaml.cs
+++ b/Jellyfin/Controls/JellyfinWebView.xaml.cs
@@ -17,7 +17,7 @@ namespace Jellyfin.Controls
     public sealed partial class JellyfinWebView : UserControl
     {
         private List<Gamepad> _connectedGamepads = new List<Gamepad>();
-        private DispatcherTimer _timer;
+        private readonly DispatcherTimer _gamepadPollingtimer;
         private bool _wasBPressed; // used to make the back button latching
         
         public JellyfinWebView()
@@ -32,11 +32,11 @@ namespace Jellyfin.Controls
             
             Gamepad.GamepadAdded += (object sender, Gamepad e) => {if (!_connectedGamepads.Contains(e)) _connectedGamepads.Add(e); };
             Gamepad.GamepadRemoved += (object sender, Gamepad e) => { _connectedGamepads.Remove(e); };
-            
-            _timer = new DispatcherTimer();
-            _timer.Interval = TimeSpan.FromMilliseconds(10);
-            _timer.Tick += GamepadPollingTimer_Tick;
-            _timer.Start();
+
+            _gamepadPollingtimer = new DispatcherTimer();
+            _gamepadPollingtimer.Interval = TimeSpan.FromMilliseconds(10);
+            _gamepadPollingtimer.Tick += GamepadPollingTimer_Tick;
+            _gamepadPollingtimer.Start();
         }
 
         private void GamepadPollingTimer_Tick(object sender, object e)

--- a/Jellyfin/Jellyfin.csproj
+++ b/Jellyfin/Jellyfin.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\AppUtils.cs" />
     <Compile Include="Utils\DeviceFormFactorType.cs" />
+    <Compile Include="Utils\GamepadManager.cs" />
     <Compile Include="Views\OnBoarding.xaml.cs">
       <DependentUpon>OnBoarding.xaml</DependentUpon>
     </Compile>

--- a/Jellyfin/Resources/JellyfinStyleResources.DeviceFamily-Desktop.xaml
+++ b/Jellyfin/Resources/JellyfinStyleResources.DeviceFamily-Desktop.xaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Jellyfin.Resources">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <SolidColorBrush x:Key="Color0" Color="#101010" />
     <SolidColorBrush x:Key="Color10" Color="#202020" />

--- a/Jellyfin/Resources/JellyfinStyleResources.xaml
+++ b/Jellyfin/Resources/JellyfinStyleResources.xaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Jellyfin.Resources">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <SolidColorBrush x:Key="Color0" Color="#101010" />
     <SolidColorBrush x:Key="Color10" Color="#202020" />

--- a/Jellyfin/Utils/GamepadManager.cs
+++ b/Jellyfin/Utils/GamepadManager.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Windows.Gaming.Input;
+using Windows.System;
+using Windows.UI.Xaml;
+
+namespace Jellyfin.Utils
+{
+    public sealed class GamepadManager
+    {
+        private readonly Dictionary<Gamepad, GamepadState> _gamepadStates = new Dictionary<Gamepad, GamepadState>();
+        private const int ButtonPressCooldownMs = 250;
+        private readonly DispatcherQueue _dispatcherQueue;
+        private readonly DispatcherTimer _gamepadPollingTimer;
+
+        public event Action OnBackPressed;
+
+        public GamepadManager()
+        {
+            _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+
+            Gamepad.GamepadAdded += Gamepad_Added;
+            Gamepad.GamepadRemoved += Gamepad_Removed;
+
+            _gamepadPollingTimer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(10),
+            };
+            _gamepadPollingTimer.Tick += GamepadPollingTimer_Tick;
+            _gamepadPollingTimer.Start();
+        }
+
+        private void Gamepad_Added(object sender, Gamepad e)
+        {
+            if (!_gamepadStates.ContainsKey(e))
+            {
+                _gamepadStates[e] = new GamepadState();
+            }
+        }
+
+        private void Gamepad_Removed(object sender, Gamepad e)
+        {
+            _gamepadStates.Remove(e);
+        }
+
+        private void GamepadPollingTimer_Tick(object sender, object e)
+        {
+            if (_dispatcherQueue.HasThreadAccess)
+            {
+                ProcessGamepadInput();
+            }
+            else
+            {
+                _dispatcherQueue.TryEnqueue(DispatcherQueuePriority.High, ProcessGamepadInput);
+            }
+        }
+
+        private void ProcessGamepadInput()
+        {
+            foreach (Gamepad gamepad in _gamepadStates.Keys)
+            {
+                GamepadState gamepadState = _gamepadStates[gamepad];
+                GamepadReading reading = gamepad.GetCurrentReading();
+                bool isBPressed = (reading.Buttons & GamepadButtons.B) == GamepadButtons.B;
+
+                if (isBPressed && !gamepadState.WasBPressed && gamepadState.ButtonCooldownTimer.ElapsedMilliseconds >= ButtonPressCooldownMs) // press detected
+                {
+                    OnBackPressed?.Invoke();
+                    gamepadState.WasBPressed = true;
+                    gamepadState.ButtonCooldownTimer.Restart();
+                }
+                else if (!isBPressed)
+                {
+                    gamepadState.WasBPressed = false;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _gamepadPollingTimer.Stop();
+            _gamepadPollingTimer.Tick -= GamepadPollingTimer_Tick;
+            Gamepad.GamepadAdded -= Gamepad_Added;
+            Gamepad.GamepadRemoved -= Gamepad_Removed;
+        }
+    }
+
+
+    public sealed class GamepadState
+    {
+        public bool WasBPressed { get; set; } // track previous state of B button
+        public Stopwatch ButtonCooldownTimer { get; set; } // tracks time since last B button press
+
+        public GamepadState()
+        {
+            WasBPressed = false;
+            ButtonCooldownTimer = new Stopwatch();
+            ButtonCooldownTimer.Start();
+        }
+    }
+}


### PR DESCRIPTION
Changes: Gamepad B button presses now navigate the user back a page with `WView.GoBack()` in the `JellyfinWebView`.

Context: The current method of navigating back a page is clicking the top left button, which can be slow for Jellyfin users who prefer or need to use a gamepad (Xbox). When the gamepad is used, the faster and more intuitive approach of pressing 'B' on the gamepad currently does nothing. 

Testing: Tested on Windows and Xbox. Works for context menus as well as page navigation.

Notes:
* This PR does not attempt to introduce d-pad navigation for scrolling and selecting title cards similar to the experience you'd find on Netflix and other similar services. I would be interested in tackling that in a future PR. 