### PR TITLE
Fix handling in OnBoarding.xaml.cs for UriBuilder

### DIFF
--- a/Jellyfin/Views/OnBoarding.xaml.cs
+++ b/Jellyfin/Views/OnBoarding.xaml.cs
@@ -52,9 +52,9 @@ namespace Jellyfin.Views
                 var ub = new UriBuilder(uriString);
                 uriString = ub.ToString();
             }
-            finally
+            catch
             {
-                ; //If the UriBuilder fails the following functions will handle the error
+                //If the UriBuilder fails the following functions will handle the error
             }
 
             if (!await CheckURLValidAsync(uriString))


### PR DESCRIPTION
Fix crashing when inputting an invalid address. Replaced the finally with a catch for UriBuilder instantiation. I am guessing this might have been a real common scenario for crashes for users.