### PR TITLE
Working controller support

### DIFF
--- a/Jellyfin/App.xaml.cs
+++ b/Jellyfin/App.xaml.cs
@@ -33,6 +33,7 @@ namespace Jellyfin
         {
             this.InitializeComponent();
             this.Suspending += OnSuspending;
+            this.RequiresPointerMode = ApplicationRequiresPointerMode.WhenRequested;
         }
 
         /// <summary>

--- a/Jellyfin/Controls/JellyfinWebView.xaml
+++ b/Jellyfin/Controls/JellyfinWebView.xaml
@@ -8,5 +8,14 @@
     mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="400">
-    <controls:WebView2 x:Name="WView"/>
+    <Grid>
+        <controls:WebView2 x:Name="WView"/>
+        <!-- This button exists only to steal focus, to work around a bug in webview2 where it doesn't focus the page properly.-->
+        <Button x:Name="BtnFocusStealer"
+                Height="1" Width="1"
+                Background="Transparent" 
+                BorderThickness="0" 
+                FocusVisualPrimaryBrush="Transparent" 
+                FocusVisualSecondaryBrush="Transparent"/>
+    </Grid>
 </UserControl>


### PR DESCRIPTION
Replaces the fake cursor with XY navigation.

# Changes:
- Now reports as Xbox in the useragent when on Xbox, this means Jellyfin-web will default to TV layout which is required for Jellyfin-web's gamepad support.
- Force enables gamepad support in Jellyfin.
- Works around a bug in WebView2 where it doesn't won't programatically focus the web content.
- Disables back button handling as Jellyfin-web handles this itself.

# Known issues:
- Left stick movement moves two spaces instead of one:
This is because WebView2 on Xbox only for some reason sends Arrow keydown events on left stick movement instead of KeyCodes 211-214. This means joystick left ends up causing a keydown event in keyboardNavigation.js, and then gamepadtokey.js fires a second one. This needs to be resolved in Jellyfin-web.
- Some face button inputs are processed twice.
Not entirely sure why this happens, but needs to be fixed from Jellyfin-web side.
- Toggling a checkbox untoggles itself
This is a bug in Jellyfin-web and also happens in other browers when using a controller. Essentially gamepadtokey.js creates a keydown event with 13, and then clicks the element on keyup.

I'm also planning to submit a some PRs to fix the Jellyfin web side. I'm suspecting we should probably bypass gamepadtokey.js altogether as a WebView on UWP provides javascript keydown events similar to how keyboard and tv remote support already works.