### PR TITLE
Enable server discovery

### DIFF
--- a/Jellyfin/App.xaml
+++ b/Jellyfin/App.xaml
@@ -2,14 +2,15 @@
     x:Class="Jellyfin.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:local="using:Jellyfin">
 
     <Application.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
+        <controls:XamlControlsResources>
+            <controls:XamlControlsResources.MergedDictionaries>
                 <ResourceDictionary Source="Resources/JellyfinStyleResources.xaml"/>
-            </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
+            </controls:XamlControlsResources.MergedDictionaries>
+        </controls:XamlControlsResources>
     </Application.Resources>
 
 </Application>

--- a/Jellyfin/Jellyfin.csproj
+++ b/Jellyfin/Jellyfin.csproj
@@ -139,10 +139,12 @@
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Models\DiscoveredServer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\AppUtils.cs" />
     <Compile Include="Utils\DeviceFormFactorType.cs" />
     <Compile Include="Utils\GamepadManager.cs" />
+    <Compile Include="Utils\ServerDiscovery.cs" />
     <Compile Include="Views\OnBoarding.xaml.cs">
       <DependentUpon>OnBoarding.xaml</DependentUpon>
     </Compile>
@@ -244,6 +246,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Web.WebView2">
       <Version>1.0.3179.45</Version>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>13.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Jellyfin/Models/DiscoveredServer.cs
+++ b/Jellyfin/Models/DiscoveredServer.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Models
+{
+    public class DiscoveredServer
+    {
+        public string Name { get; set; }
+        public Guid Id { get; set; }
+        public Uri Address { get; set; }
+        public Uri EndpointAddress { get; set; }
+
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            var otherServer = (DiscoveredServer)obj;
+            return this.Id == otherServer.Id;
+        }
+    }
+}

--- a/Jellyfin/Utils/ServerDiscovery.cs
+++ b/Jellyfin/Utils/ServerDiscovery.cs
@@ -1,0 +1,90 @@
+﻿using Jellyfin.Models;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.Core;
+using Windows.System;
+using Windows.System.Threading;
+using Windows.UI.Xaml;
+
+namespace Jellyfin.Utils
+{
+    public class ServerDiscovery: IDisposable
+    {
+
+        private readonly TimeSpan _discoverInterval = TimeSpan.FromSeconds(10);
+        private readonly ThreadPoolTimer _discoveryTimer;
+        private readonly byte[] _sendBuffer = Encoding.ASCII.GetBytes("Who is JellyfinServer?");
+
+        public event Action OnDiscover;
+
+        public Queue<DiscoveredServer> DiscoveredServers { get; } = new Queue<DiscoveredServer>(); 
+
+        public ServerDiscovery()
+        {
+            _discoveryTimer = ThreadPoolTimer.CreatePeriodicTimer(DiscoveryPolling_Timer, _discoverInterval);
+            new Thread(() => { DiscoverServers(); }).Start();
+        }
+
+        private void DiscoveryPolling_Timer(object sender)
+        {
+            DiscoverServers();
+        }
+
+        private void DiscoverServers()
+        {
+            using (var udpSocket = new Socket(SocketType.Dgram, ProtocolType.Udp))
+            {
+                Debug.WriteLine("New UDPSocket");
+                udpSocket.EnableBroadcast = true;
+                udpSocket.ReceiveTimeout = (int) _discoverInterval.TotalMilliseconds;
+
+                var broadcastAddress = IPAddress.Broadcast;
+                var broadcastEndpoint = new IPEndPoint(broadcastAddress, 7359);
+                udpSocket.SendTo(_sendBuffer, broadcastEndpoint);
+                Debug.WriteLine($"Sent to {broadcastAddress}");
+
+                var recieveBuffer = new byte[256];
+                try
+                {
+                    while (true)
+                    {
+                        udpSocket.Receive(recieveBuffer);
+                        var receivedText = Encoding.ASCII.GetString(recieveBuffer, 0, recieveBuffer.Length);
+                        Debug.WriteLine($"Received: {receivedText}");
+                        var discoveredServer = JsonConvert.DeserializeObject<DiscoveredServer>(receivedText);
+
+                        DiscoveredServers.Enqueue(discoveredServer);
+                        OnDiscover?.Invoke();
+                    }
+                }
+                catch (SocketException ex)
+                {
+                    if (ex.SocketErrorCode == SocketError.TimedOut)
+                    {
+                        Debug.WriteLine($"Socket Timed out after {_discoverInterval.TotalSeconds}s");
+                    } 
+                    else
+                    {
+                        Debug.WriteLine($"Broadcast Address: {broadcastAddress}, errored with message: {ex.Message}");
+                        throw ex;
+                    }
+                }
+            }
+            Debug.WriteLine("UDPSocket ended");
+        }
+
+        public void Dispose()
+        {
+            _discoveryTimer.Cancel();
+        }
+    }
+}

--- a/Jellyfin/Views/OnBoarding.xaml
+++ b/Jellyfin/Views/OnBoarding.xaml
@@ -8,14 +8,10 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
     Unloaded="Page_Unloaded"
     mc:Ignorable="d">
 
-    <Page.Resources>
-        <converters:CollectionVisibilityConverter x:Name="CollectionVisibilityConverter"/>
-    </Page.Resources>
-
+    
     <Grid Background="{StaticResource Color0}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup>
@@ -51,6 +47,14 @@
                 HorizontalAlignment="Center" 
                 Height="80" />
         </Grid>
+
+        <muxc:ProgressRing
+            x:Name="spinnerConnecting"
+            Grid.RowSpan="2" 
+            Grid.ColumnSpan="2"
+            Height="100"
+            Width="100"
+            IsActive="False"/>
 
         <Grid Grid.Row="1" Padding="0 40 0 0">
             <StackPanel 
@@ -106,7 +110,7 @@
                 </StackPanel>
 
 
-                <ListView x:Name="DiscoveredList" IsItemClickEnabled="True" ItemClick="DiscoveredList_ItemClick" ItemsSource="{x:Bind _discoveredServers}">
+                <ListView x:Name="lstDiscovered" IsItemClickEnabled="True" ItemClick="DiscoveredList_ItemClick" ItemsSource="{x:Bind _discoveredServers}">
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="models:DiscoveredServer">
                             <StackPanel>

--- a/Jellyfin/Views/OnBoarding.xaml
+++ b/Jellyfin/Views/OnBoarding.xaml
@@ -4,9 +4,17 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Jellyfin.Views"
     xmlns:c="using:Jellyfin.Controls"
+    xmlns:models="using:Jellyfin.Models"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+    Unloaded="Page_Unloaded"
     mc:Ignorable="d">
+
+    <Page.Resources>
+        <converters:CollectionVisibilityConverter x:Name="CollectionVisibilityConverter"/>
+    </Page.Resources>
 
     <Grid Background="{StaticResource Color0}">
         <VisualStateManager.VisualStateGroups>
@@ -30,8 +38,12 @@
             <RowDefinition x:Name="RowHeader" Height="200" />
             <RowDefinition />
         </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
 
-        <Grid Background="{StaticResource Color10}">
+        <Grid Background="{StaticResource Color10}" Grid.ColumnSpan="2">
             <Image 
                 x:Name="logo" 
                 Source="/Assets/OnBoardingLogo.png" 
@@ -74,6 +86,43 @@
                     Content="Connect"  />
             </StackPanel>
         </Grid>
-        
+
+        <Grid Grid.Row="1" Grid.Column="1">
+            <StackPanel 
+    x:Name="pnlDiscoveryTitle" 
+    HorizontalAlignment="Center" 
+    VerticalAlignment="Top" 
+    Width="640">
+                <StackPanel Orientation="Horizontal"
+                            HorizontalAlignment="Center"
+>
+                    <TextBlock
+        x:Name="txtDiscoverTitle"
+        Text="Discover Server" 
+        Foreground="White" FontSize="{StaticResource FontL}"
+        Margin="0 0 0 28" FontFamily="{StaticResource JellyfinFamilyFont}"
+                        Padding="0 40 0 0"
+        HorizontalAlignment="Center" />
+                </StackPanel>
+
+
+                <ListView x:Name="DiscoveredList" IsItemClickEnabled="True" ItemClick="DiscoveredList_ItemClick" ItemsSource="{x:Bind _discoveredServers}">
+                    <ListView.ItemTemplate>
+                        <DataTemplate x:DataType="models:DiscoveredServer">
+                            <StackPanel>
+                                <TextBlock Text="{x:Bind Name}" FontSize="{StaticResource FontM}"/>
+                                <TextBlock Text="{x:Bind Address}" FontSize="{StaticResource FontS}"/>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                    <ListView.Footer>
+                        <TextBlock x:Name="txtDiscoverNoneFound" FontSize="{StaticResource FontM}" 
+                                   HorizontalAlignment="Center">
+                            No servers found, searching.
+                        </TextBlock>
+                    </ListView.Footer>
+                </ListView>
+            </StackPanel>
+        </Grid>
     </Grid>
 </Page>

--- a/Jellyfin/Views/OnBoarding.xaml
+++ b/Jellyfin/Views/OnBoarding.xaml
@@ -92,25 +92,7 @@
         </Grid>
 
         <Grid Grid.Row="1" Grid.Column="1">
-            <StackPanel 
-    x:Name="pnlDiscoveryTitle" 
-    HorizontalAlignment="Center" 
-    VerticalAlignment="Top" 
-    Width="640">
-                <StackPanel Orientation="Horizontal"
-                            HorizontalAlignment="Center"
->
-                    <TextBlock
-        x:Name="txtDiscoverTitle"
-        Text="Discover Server" 
-        Foreground="White" FontSize="{StaticResource FontL}"
-        Margin="0 0 0 28" FontFamily="{StaticResource JellyfinFamilyFont}"
-                        Padding="0 40 0 0"
-        HorizontalAlignment="Center" />
-                </StackPanel>
-
-
-                <ListView x:Name="lstDiscovered" IsItemClickEnabled="True" ItemClick="DiscoveredList_ItemClick" ItemsSource="{x:Bind _discoveredServers}">
+            <ListView x:Name="lstDiscovered" IsItemClickEnabled="True" ItemClick="DiscoveredList_ItemClick" ItemsSource="{x:Bind _discoveredServers}">
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="models:DiscoveredServer">
                             <StackPanel>
@@ -119,14 +101,22 @@
                             </StackPanel>
                         </DataTemplate>
                     </ListView.ItemTemplate>
-                    <ListView.Footer>
+                <ListView.Header>
+                    <StackPanel>
+                        <TextBlock
+                            x:Name="txtDiscoverTitle"
+                            Text="Discover Server" 
+                            Foreground="White" FontSize="{StaticResource FontL}"
+                            Margin="0 0 0 28" FontFamily="{StaticResource JellyfinFamilyFont}"
+                                            Padding="0 40 0 0"
+                            HorizontalAlignment="Center" />
                         <TextBlock x:Name="txtDiscoverNoneFound" FontSize="{StaticResource FontM}" 
-                                   HorizontalAlignment="Center">
+                                   HorizontalAlignment="Center" TextWrapping="WrapWholeWords">
                             No servers found, searching.
                         </TextBlock>
-                    </ListView.Footer>
-                </ListView>
-            </StackPanel>
+                    </StackPanel>
+                </ListView.Header>
+            </ListView>
         </Grid>
     </Grid>
 </Page>

--- a/Jellyfin/Views/OnBoarding.xaml.cs
+++ b/Jellyfin/Views/OnBoarding.xaml.cs
@@ -58,9 +58,7 @@ namespace Jellyfin.Views
 
         private async void BtnConnect_Click(object sender, RoutedEventArgs e)
         {
-            btnConnect.IsEnabled = false;
-            txtError.Visibility = Visibility.Collapsed;
-
+            ConnectionStatusChanged(true);
             string uriString = txtUrl.Text;
             try
             {
@@ -73,8 +71,6 @@ namespace Jellyfin.Views
             }
 
             await TryConnect(uriString);
-
-            btnConnect.IsEnabled = true;
         }
 
         private void OnBoarding_Loaded(object sender, RoutedEventArgs e)
@@ -108,6 +104,18 @@ namespace Jellyfin.Views
             {
                 Central.Settings.JellyfinServer = uriString;
                 (Window.Current.Content as Frame).Navigate(typeof(MainPage));
+            }
+            ConnectionStatusChanged(false);
+        }
+
+        private void ConnectionStatusChanged(bool connecting)
+        {
+            spinnerConnecting.IsActive = connecting;
+            btnConnect.IsEnabled = !connecting;
+            lstDiscovered.IsEnabled = !connecting;
+            if (connecting)
+            {
+                txtError.Visibility = Visibility.Collapsed;
             }
         }
 

--- a/Jellyfin/Views/OnBoarding.xaml.cs
+++ b/Jellyfin/Views/OnBoarding.xaml.cs
@@ -1,11 +1,21 @@
 ﻿using Jellyfin.Core;
+using Jellyfin.Models;
+using Jellyfin.Utils;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
 using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Windows.ApplicationModel.Core;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using Windows.UI.Xaml;
@@ -25,12 +35,17 @@ namespace Jellyfin.Views
     /// </summary>
     public sealed partial class OnBoarding : Page
     {
+        private ObservableCollection<DiscoveredServer> _discoveredServers = new ObservableCollection<DiscoveredServer>();
+        private List<Socket> _sockets = new List<Socket>();
+        private ServerDiscovery _serverDiscovery = new ServerDiscovery();
+
         public OnBoarding()
         {
             this.InitializeComponent();
             this.Loaded += OnBoarding_Loaded;
             btnConnect.Click += BtnConnect_Click;
             txtUrl.KeyUp += TxtUrl_KeyUp;
+            _serverDiscovery.OnDiscover += _serverDiscovery_OnDiscover;
         }
 
         private void TxtUrl_KeyUp(object sender, KeyRoutedEventArgs e)
@@ -57,6 +72,34 @@ namespace Jellyfin.Views
                 //If the UriBuilder fails the following functions will handle the error
             }
 
+            await TryConnect(uriString);
+
+            btnConnect.IsEnabled = true;
+        }
+
+        private void OnBoarding_Loaded(object sender, RoutedEventArgs e)
+        {
+            txtUrl.Focus(FocusState.Programmatic);
+        }
+
+        private async void _serverDiscovery_OnDiscover()
+        {
+            DiscoveredServer discoveredServer = null;
+            while (_serverDiscovery.DiscoveredServers.TryDequeue(out discoveredServer))
+            {
+                await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+                {
+                    if (!_discoveredServers.Contains(discoveredServer))
+                    {
+                        _discoveredServers.Add(discoveredServer);
+                        txtDiscoverNoneFound.Visibility = Visibility.Collapsed;
+                    }
+                });
+            }
+        }
+
+        private async Task TryConnect(string uriString)
+        {
             if (!await CheckURLValidAsync(uriString))
             {
                 txtError.Visibility = Visibility.Visible;
@@ -66,13 +109,6 @@ namespace Jellyfin.Views
                 Central.Settings.JellyfinServer = uriString;
                 (Window.Current.Content as Frame).Navigate(typeof(MainPage));
             }
-
-            btnConnect.IsEnabled = true;
-        }
-
-        private void OnBoarding_Loaded(object sender, RoutedEventArgs e)
-        {
-            txtUrl.Focus(FocusState.Programmatic);
         }
 
         private async Task<bool> CheckURLValidAsync(string uriString)
@@ -149,6 +185,22 @@ namespace Jellyfin.Views
         {
             txtError.Visibility = Visibility.Visible;
             txtError.Text = $"Error: {statusCode}";
+        }
+
+        private async void DiscoveredList_ItemClick(object clickedItem, ItemClickEventArgs e)
+        {
+            var discoveredServer = (DiscoveredServer) e.ClickedItem;
+            var addressString = discoveredServer.Address.ToString();
+            txtUrl.Text = addressString;
+            await TryConnect(addressString);
+        }
+
+        private void Page_Unloaded(object sender, RoutedEventArgs e)
+        {
+            foreach (var socket in _sockets)
+            {
+                socket.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
Allows servers to be autodetected over the network.

- Split the onboarding view in half. Left pane for manual input, right pane for detected servers. Similar to Jellyfin AndroidTV.
- In the background it broadcasts Jellyfin discovery packets every 10s.
- Added a loading spinner to show when the page is doing work.

I did also spend some time working on converting the OnBoarding view to MVVM in another branch if that's of interest, but I wasn't sure if that would be a welcome change so I left it out of the initial PR.

# Screenshots:
<img width="400" alt="OnBoarding screen where no servers are detected." src="https://github.com/user-attachments/assets/2b8e2352-c4fc-4deb-a6cb-4279af78e1bf" />
<img width="400" alt="OnBoarding screen with one server detected. Labeled with servername and link." src="https://github.com/user-attachments/assets/5655c9ff-aab3-4597-8983-3a90c82a8e9c" />
<img width="400" alt="Onboarding screen with new loading spinner" src="https://github.com/user-attachments/assets/e6156e3e-5203-4292-9daf-ee3cf5d8ea97" />

